### PR TITLE
[feat] #1 공통 응답형식 및 예외 핸들링 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,16 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	runtimeOnly 'com.h2database:h2'
+
+	// spring web
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/hyundai/common/advice/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/hyundai/common/advice/GlobalExceptionHandler.java
@@ -1,0 +1,50 @@
+package org.sopt.hyundai.common.advice;
+
+import org.sopt.hyundai.common.code.ErrorCode;
+import org.sopt.hyundai.common.response.ResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // @Valid 예외
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Map<String, String>>> handleValidationException(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(err ->
+                errors.put(err.getField(), err.getDefaultMessage())
+        );
+
+        return ResponseEntity
+                .status(ErrorCode.INVALID_INPUT_VALUE.getHttpStatus())
+                .body(ResponseDto.fail(ErrorCode.INVALID_INPUT_VALUE.getCode(), errors));
+    }
+
+    // 존재하지 않는 요청에 대한 예외
+    @ExceptionHandler(value = {NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
+    public ResponseEntity<ResponseDto<Void>> handleNoPageFoundException(Exception e) {
+        ErrorCode errorCode = e instanceof HttpRequestMethodNotSupportedException
+                ? ErrorCode.METHOD_NOT_ALLOWED
+                : ErrorCode.NOT_FOUND_END_POINT;
+
+        return ResponseEntity
+                .status(errorCode.getHttpStatus())
+                .body(ResponseDto.fail(errorCode));
+    }
+
+    // 기본 예외
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseDto<Void>> handleException(Exception e){
+        return ResponseEntity
+                .status(ErrorCode.INTERNAL_SERVER_ERROR.getHttpStatus())
+                .body(ResponseDto.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+    }
+}

--- a/src/main/java/org/sopt/hyundai/common/advice/ResponseWrappingAdvice.java
+++ b/src/main/java/org/sopt/hyundai/common/advice/ResponseWrappingAdvice.java
@@ -1,0 +1,40 @@
+package org.sopt.hyundai.common.advice;
+
+import lombok.NonNull;
+import org.sopt.hyundai.common.code.SuccessCode;
+import org.sopt.hyundai.common.response.ResponseDto;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(
+        basePackages = "org.sopt"
+)
+public class ResponseWrappingAdvice implements ResponseBodyAdvice<Object> {
+    @Override
+    public boolean supports(MethodParameter returnType, @NonNull Class converterType) {
+        return !(returnType.getParameterType() == ResponseDto.class)
+                && MappingJackson2HttpMessageConverter.class.isAssignableFrom(converterType);
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            @NonNull MethodParameter returnType,
+            @NonNull MediaType selectedContentType,
+            @NonNull Class selectedConverterType,
+            @NonNull ServerHttpRequest request,
+            @NonNull ServerHttpResponse response
+    ) {
+        if (body instanceof ResponseEntity || body instanceof ResponseDto<?>) {
+            return body;
+        }
+
+        return ResponseDto.success(SuccessCode.OK, body);
+    }
+}

--- a/src/main/java/org/sopt/hyundai/common/code/ApiCode.java
+++ b/src/main/java/org/sopt/hyundai/common/code/ApiCode.java
@@ -1,0 +1,9 @@
+package org.sopt.hyundai.common.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ApiCode {
+    HttpStatus getHttpStatus();
+    int getCode();
+    String getMessage();
+}

--- a/src/main/java/org/sopt/hyundai/common/code/ErrorCode.java
+++ b/src/main/java/org/sopt/hyundai/common/code/ErrorCode.java
@@ -1,0 +1,39 @@
+package org.sopt.hyundai.common.code;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode implements ApiCode{
+    // 400
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, 400, "잘못된 요청 값입니다."),
+    NOT_FOUND_END_POINT(HttpStatus.NOT_FOUND, 404, "요청한 API 엔드포인트가 존재하지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, 405, "지원하지 않는 HTTP 메서드입니다."),
+
+    // 500
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 500, "알 수 없는 서버 내부 오류입니다"),
+    ;
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, int code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return status;
+    }
+
+    @Override
+    public int getCode() {
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/hyundai/common/code/SuccessCode.java
+++ b/src/main/java/org/sopt/hyundai/common/code/SuccessCode.java
@@ -1,0 +1,35 @@
+package org.sopt.hyundai.common.code;
+
+import org.springframework.http.HttpStatus;
+
+public enum SuccessCode implements ApiCode {
+    OK(HttpStatus.OK, 200,"요청이 성공했습니다."),
+    CREATED(HttpStatus.CREATED, 201, "요청이 성공했습니다."),
+    NO_CONTENT(HttpStatus.NO_CONTENT,204,"요청이 성공했습니다.")
+    ;
+
+    public final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+
+    SuccessCode(HttpStatus httpStatus, int code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getHttpStatus(){
+        return httpStatus;
+    }
+
+    @Override
+    public int getCode(){
+        return code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/org/sopt/hyundai/common/response/ResponseDto.java
+++ b/src/main/java/org/sopt/hyundai/common/response/ResponseDto.java
@@ -1,0 +1,24 @@
+package org.sopt.hyundai.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.sopt.hyundai.common.code.ErrorCode;
+import org.sopt.hyundai.common.code.SuccessCode;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ResponseDto<T>(
+        int code,
+        T data,
+        String message
+) {
+    public static <T> ResponseDto<T> success(SuccessCode code, final T data) {
+        return new ResponseDto<>(code.getCode(), data, null);
+    }
+
+    public static <T> ResponseDto<T> fail(ErrorCode code) {
+        return new ResponseDto<>(code.getCode(), null, code.getMessage());
+    }
+
+    public static <T> ResponseDto<T> fail(int code, final T data) {
+        return new ResponseDto<>(code, data, null);
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #1 

## Work Description ✏️
<!-- 작업 내용을 간단히 소개주세요 -->
공통 응답 형식 및 예외 핸들링을 세팅했습니다.
### Success
<img width="846" alt="image" src="https://github.com/user-attachments/assets/3f10e796-45d6-473b-86af-e24d4f450112" />

&nbsp;

### Fail
<img width="848" alt="image" src="https://github.com/user-attachments/assets/e94e3e95-c949-4c28-86ec-2c22a09fad23" />

&nbsp;

###
- 구현하다가 발생하는 예외는 GlobalExceptionHandler 에 등록하여 사용하면 됩니다.
- 응답값에서 null 필드는 반환하지 않도록 했습니다. (클라 요청)


## To Reviewers 📢
궁금한 점 있으면 편하게 질문주세요!
숨참고 현카 다이브 ~~~~ ><
